### PR TITLE
Update ndc test

### DIFF
--- a/tests/chem.py
+++ b/tests/chem.py
@@ -133,10 +133,10 @@ class TestChemClient(unittest.TestCase):
         self.assertEqual(qres['hits'][0]['_id'], 'ZRALSGWEFCBTJO-UHFFFAOYSA-N')
 
     def test_query_ndc(self):
-        qres = self.mc.query('ndc.productndc:"0085-0492"')
+        qres = self.mc.query('ndc.productndc:"0456-2700"')
         self.assertTrue('hits' in qres)
         self.assertEqual(len(qres['hits']), 1)
-        self.assertEqual(qres['hits'][0]['_id'], 'ZRALSGWEFCBTJO-UHFFFAOYSA-N')
+        self.assertEqual(qres['hits'][0]['_id'], 'NDCUAPJVLWFHHB-UHNVWZDZSA-N')
 
     def test_query_sider(self):
         qres = self.mc.query('sider.meddra.umls_id:C0232487', fields='sider', size=5)

--- a/tests/chem.py
+++ b/tests/chem.py
@@ -133,10 +133,10 @@ class TestChemClient(unittest.TestCase):
         self.assertEqual(qres['hits'][0]['_id'], 'ZRALSGWEFCBTJO-UHFFFAOYSA-N')
 
     def test_query_ndc(self):
-        qres = self.mc.query('ndc.productndc:"0456-2700"')
+        qres = self.mc.query('ndc.productndc:"27437-051"')
         self.assertTrue('hits' in qres)
         self.assertEqual(len(qres['hits']), 1)
-        self.assertEqual(qres['hits'][0]['_id'], 'NDCUAPJVLWFHHB-UHNVWZDZSA-N')
+        self.assertEqual(qres['hits'][0]['_id'], 'KPQZUUQMTUIKBP-UHFFFAOYSA-N')
 
     def test_query_sider(self):
         qres = self.mc.query('sider.meddra.umls_id:C0232487', fields='sider', size=5)


### PR DESCRIPTION
NDC removed or deprecated the product code that was being used for the previous test, so I'm substituting a new one.

Previous id: https://api.fda.gov/drug/ndc.json?search=product_ndc:0085-0492
New id: https://api.fda.gov/drug/ndc.json?search=product_ndc:27437-051

http://mychem.info/v1/query?q=ndc.productndc:27437-051&fields=ndc