### PR TITLE
Set log level for biothings_client only, not generally for all packages

### DIFF
--- a/biothings_client/base.py
+++ b/biothings_client/base.py
@@ -37,8 +37,8 @@ except ImportError:
 
 __version__ = "0.3.0"
 
-logging.basicConfig(level="INFO")
 logger = logging.getLogger("biothings.client")
+logger.setLevel(logging.INFO)
 
 # Future work:
 # Consider use "verbose" settings to control default logging output level


### PR DESCRIPTION
Hi! Not sure if this is the right branch to submit a PR, feel free to change if not.

With the latest version of biothings_client, the logging config is set in such a way that the default log status changes for other packages as well. This means that various Python packages suddenly start logging, sometimes quite a lot. In this PR, I've changed the logger setup such that the level is only affecting biothings and not other packages. 

As an example, here is an import with the version 0.3.0 of biothings_client:

![image](https://github.com/biothings/biothings_client.py/assets/281252/8fb98cc0-6bac-4232-a103-5d7b99019599)

With the proposed PR, the import doesn't print these log messages anymore.

PS: Thanks so much for providing biothings & mygene, these are great tools, much appreciated.