### PR TITLE
Upgrade default client url's to https

### DIFF
--- a/biothings_client/__init__.py
+++ b/biothings_client/__init__.py
@@ -126,7 +126,7 @@ MYTAXON_KWARGS.update(
 MYGENESET_KWARGS = copy(COMMON_KWARGS)
 MYGENESET_KWARGS.update(
     {
-        "_default_url": "https://mygeneset.info/v1",
+        "_default_url": "http://mygeneset.info/v1",
         "_annotation_endpoint": "/geneset/",
         "_optionally_plural_object_type": "geneset(s)",
         "_entity": "geneset",

--- a/biothings_client/__init__.py
+++ b/biothings_client/__init__.py
@@ -72,7 +72,7 @@ COMMON_KWARGS = {
 MYGENE_KWARGS = copy(COMMON_KWARGS)
 MYGENE_KWARGS.update(
     {
-        "_default_url": "http://mygene.info/v3",
+        "_default_url": "https://mygene.info/v3",
         "_annotation_endpoint": "/gene/",
         "_optionally_plural_object_type": "gene(s)",
         "_default_cache_file": "mygene_cache",
@@ -83,7 +83,7 @@ MYGENE_KWARGS.update(
 MYVARIANT_KWARGS = copy(COMMON_KWARGS)
 MYVARIANT_KWARGS.update(
     {
-        "_default_url": "http://myvariant.info/v1",
+        "_default_url": "https://myvariant.info/v1",
         "_annotation_endpoint": "/variant/",
         "_optionally_plural_object_type": "variant(s)",
         "_default_cache_file": "myvariant_cache",
@@ -95,7 +95,7 @@ MYVARIANT_KWARGS.update(
 MYCHEM_KWARGS = copy(COMMON_KWARGS)
 MYCHEM_KWARGS.update(
     {
-        "_default_url": "http://mychem.info/v1",
+        "_default_url": "https://mychem.info/v1",
         "_annotation_endpoint": "/chem/",
         "_optionally_plural_object_type": "chem(s)",
         "_entity": "chem",
@@ -106,7 +106,7 @@ MYCHEM_KWARGS.update(
 MYDISEASE_KWARGS = copy(COMMON_KWARGS)
 MYDISEASE_KWARGS.update(
     {
-        "_default_url": "http://mydisease.info/v1",
+        "_default_url": "https://mydisease.info/v1",
         "_annotation_endpoint": "/disease/",
         "_optionally_plural_object_type": "disease(s)",
         "_entity": "disease",
@@ -116,7 +116,7 @@ MYDISEASE_KWARGS.update(
 MYTAXON_KWARGS = copy(COMMON_KWARGS)
 MYTAXON_KWARGS.update(
     {
-        "_default_url": "http://t.biothings.io/v1",
+        "_default_url": "https://t.biothings.io/v1",
         "_annotation_endpoint": "/taxon/",
         "_optionally_plural_object_type": "taxon/taxa",
         "_entity": "taxon",
@@ -126,7 +126,7 @@ MYTAXON_KWARGS.update(
 MYGENESET_KWARGS = copy(COMMON_KWARGS)
 MYGENESET_KWARGS.update(
     {
-        "_default_url": "http://mygeneset.info/v1",
+        "_default_url": "https://mygeneset.info/v1",
         "_annotation_endpoint": "/geneset/",
         "_optionally_plural_object_type": "geneset(s)",
         "_entity": "geneset",


### PR DESCRIPTION
These packages are all available over https:
- [http://mygene.info/v3](https://smart-api.info/ui/59dce17363dce279d389100834e43648)
- [http://myvariant.info/v1](https://smart-api.info/ui/09c8782d9f4027712e65b95424adba79)
- [http://mychem.info/v1](https://smart-api.info/ui/8f08d1446e0bb9c2b323713ce83e2bd3)
- [http://mydisease.info/v1](https://smart-api.info/ui/671b45c0301c8624abbd26ae78449ca2)
- [t.biothings.io/v1](https://smart-api.info/ui/f7943e6167166b3ea9e4b8be08f45fa6)

"mygeneset.info/v1" returns a 404 url regardless of http or https.