### PR TITLE
Bugfix client proxy autodiscovery

### DIFF
--- a/biothings_client/__init__.py
+++ b/biothings_client/__init__.py
@@ -6,6 +6,7 @@ from biothings_client.client.asynchronous import AsyncBiothingClient, get_async_
 from biothings_client.client.base import BiothingClient, get_client
 from biothings_client.__version__ import __version__
 from biothings_client._dependencies import _CACHING, _PANDAS
+from biothings_client.utils._external import alwayslist
 
 __all__ = [
     "AsyncBiothingClient",
@@ -13,6 +14,7 @@ __all__ = [
     "_CACHING",
     "_PANDAS",
     "__version__",
+    "alwayslist",
     "get_async_client",
     "get_client",
 ]

--- a/biothings_client/client/asynchronous.py
+++ b/biothings_client/client/asynchronous.py
@@ -103,6 +103,12 @@ class AsyncBiothingClient:
         This modifies the state of the BiothingsClient instance
         to set the values for the http_client property
 
+        For the moment, we have disabled timeouts. This matches our prior
+        behavior we had with the requests library, which by default did not
+        specify a timeout when making a request. In the future this should
+        be modified to prevent indefinite hanging with potentially bad network
+        connections
+
         Inputs:
         :param cache_db: pathlike object to the local sqlite3 cache database file
 
@@ -110,7 +116,7 @@ class AsyncBiothingClient:
         :return: None
         """
         if not self.http_client_setup:
-            self.http_client = httpx.AsyncClient()
+            self.http_client = httpx.AsyncClient(timeout=None)
             self.http_client_setup = True
             self.http_cache_client_setup = False
 
@@ -123,6 +129,12 @@ class AsyncBiothingClient:
 
         This modifies the state of the BiothingsClient instance
         to set the values for the http_client property and the cache_storage property
+
+        For the moment, we have disabled timeouts. This matches our prior
+        behavior we had with the requests library, which by default did not
+        specify a timeout when making a request. In the future this should
+        be modified to prevent indefinite hanging with potentially bad network
+        connections
 
         Inputs:
         :param cache_db: pathlike object to the local sqlite3 cache database file
@@ -146,7 +158,11 @@ class AsyncBiothingClient:
             # proxies if we provide our own HTTPTransport to the Client constructor
             proxy_mounts = self._build_caching_proxy_mounts()
             self.http_client = hishel.AsyncCacheClient(
-                controller=cache_controller, transport=cache_transport, storage=self.cache_storage, mounts=proxy_mounts
+                controller=cache_controller,
+                transport=cache_transport,
+                storage=self.cache_storage,
+                mounts=proxy_mounts,
+                timeout=None,
             )
             self.http_client_setup = True
 

--- a/biothings_client/client/asynchronous.py
+++ b/biothings_client/client/asynchronous.py
@@ -48,7 +48,7 @@ logger = logging.getLogger("biothings.client")
 logger.setLevel(logging.INFO)
 
 
-PROXY_MOUNT = dict[str, httpx.BaseTransport | None]
+PROXY_MOUNT = Dict[str, Union[httpx.BaseTransport, None]]
 
 
 # Future work:

--- a/biothings_client/client/asynchronous.py
+++ b/biothings_client/client/asynchronous.py
@@ -48,6 +48,9 @@ logger = logging.getLogger("biothings.client")
 logger.setLevel(logging.INFO)
 
 
+PROXY_MOUNT = dict[str, httpx.BaseTransport | None]
+
+
 # Future work:
 # Consider use "verbose" settings to control default logging output level
 # by doing this instead of using branching throughout the application,
@@ -134,14 +137,42 @@ class AsyncBiothingClient:
 
             self.cache_storage = AsyncBiothingsClientSqlite3Cache()
             await self.cache_storage.setup_database_connection(cache_db)
-            cache_transport = hishel.AsyncCacheTransport(
-                transport=httpx.AsyncHTTPTransport(), storage=self.cache_storage
-            )
+
+            async_http_transport = httpx.AsyncHTTPTransport()
+            cache_transport = hishel.AsyncCacheTransport(transport=async_http_transport, storage=self.cache_storage)
             cache_controller = hishel.Controller(cacheable_methods=["GET", "POST"])
+
+            # Have to manually build the proxy mounts as httpx will not auto-discover
+            # proxies if we provide our own HTTPTransport to the Client constructor
+            proxy_mounts = self._build_caching_proxy_mounts()
             self.http_client = hishel.AsyncCacheClient(
-                controller=cache_controller, transport=cache_transport, storage=self.cache_storage
+                controller=cache_controller, transport=cache_transport, storage=self.cache_storage, mounts=proxy_mounts
             )
             self.http_client_setup = True
+
+    def _build_caching_proxy_mounts(self) -> PROXY_MOUNT:
+        """
+        Builds the proxy mounts for case where we have a CacheTransport.
+        Autodiscovery of proxies only works when don't provide a transport
+        to the client so this method acts as a replacement for that
+        """
+        proxy_map = httpx._utils.get_environment_proxies()
+        proxy_mounts: PROXY_MOUNT = {}
+        for key, proxy in proxy_map.items():
+            proxy_transport = None
+            if proxy is not None:
+                proxy_transport = httpx.AsyncHTTPTransport(
+                    verify=True,
+                    cert=None,
+                    trust_env=True,
+                    http1=True,
+                    http2=False,
+                    limits=httpx._config.DEFAULT_LIMITS,
+                    proxy=proxy,
+                )
+            proxy_mounts[key] = proxy_transport
+        proxy_mounts = dict(sorted(proxy_mounts.items()))
+        return proxy_mounts
 
     async def __del__(self):
         """

--- a/biothings_client/client/asynchronous.py
+++ b/biothings_client/client/asynchronous.py
@@ -107,8 +107,7 @@ class AsyncBiothingClient:
         :return: None
         """
         if not self.http_client_setup:
-            http_transport = httpx.AsyncHTTPTransport()
-            self.http_client = httpx.AsyncClient(transport=http_transport)
+            self.http_client = httpx.AsyncClient()
             self.http_client_setup = True
             self.http_cache_client_setup = False
 

--- a/biothings_client/client/base.py
+++ b/biothings_client/client/base.py
@@ -49,7 +49,7 @@ logger = logging.getLogger("biothings.client")
 logger.setLevel(logging.INFO)
 
 
-PROXY_MOUNT = dict[httpx._utils.URLPattern, httpx.BaseTransport | None]
+PROXY_MOUNT = Dict[str, Union[httpx.BaseTransport, None]]
 
 
 # Future work:

--- a/biothings_client/client/base.py
+++ b/biothings_client/client/base.py
@@ -105,8 +105,7 @@ class BiothingClient:
         to set the values for the http_client property
         """
         if not self.http_client_setup:
-            http_transport = httpx.HTTPTransport()
-            self.http_client = httpx.Client(transport=http_transport)
+            self.http_client = httpx.Client()
             self.http_client_setup = True
             self.http_cache_client_setup = False
 

--- a/biothings_client/client/base.py
+++ b/biothings_client/client/base.py
@@ -106,9 +106,15 @@ class BiothingClient:
 
         This modifies the state of the BiothingsClient instance
         to set the values for the http_client property
+
+        For the moment, we have disabled timeouts. This matches our prior
+        behavior we had with the requests library, which by default did not
+        specify a timeout when making a request. In the future this should
+        be modified to prevent indefinite hanging with potentially bad network
+        connections
         """
         if not self.http_client_setup:
-            self.http_client = httpx.Client()
+            self.http_client = httpx.Client(timeout=None)
             self.http_client_setup = True
             self.http_cache_client_setup = False
 
@@ -121,6 +127,12 @@ class BiothingClient:
 
         This modifies the state of the BiothingsClient instance
         to set the values for the http_client property and the cache_storage property
+
+        For the moment, we have disabled timeouts. This matches our prior
+        behavior we had with the requests library, which by default did not
+        specify a timeout when making a request. In the future this should
+        be modified to prevent indefinite hanging with potentially bad network
+        connections
         """
         if not self.http_client_setup:
             if cache_db is None:
@@ -138,7 +150,11 @@ class BiothingClient:
             # proxies if we provide our own HTTPTransport to the Client constructor
             proxy_mounts = self._build_caching_proxy_mounts()
             self.http_client = hishel.CacheClient(
-                controller=cache_controller, transport=cache_transport, storage=self.cache_storage, mounts=proxy_mounts
+                controller=cache_controller,
+                transport=cache_transport,
+                storage=self.cache_storage,
+                mounts=proxy_mounts,
+                timeout=None,
             )
             self.http_client_setup = True
 

--- a/biothings_client/client/base.py
+++ b/biothings_client/client/base.py
@@ -49,6 +49,9 @@ logger = logging.getLogger("biothings.client")
 logger.setLevel(logging.INFO)
 
 
+PROXY_MOUNT = dict[httpx._utils.URLPattern, httpx.BaseTransport | None]
+
+
 # Future work:
 # Consider use "verbose" settings to control default logging output level
 # by doing this instead of using branching throughout the application,
@@ -126,12 +129,42 @@ class BiothingClient:
 
             self.cache_storage = BiothingsClientSqlite3Cache()
             self.cache_storage.setup_database_connection(cache_db)
-            cache_transport = hishel.CacheTransport(transport=httpx.HTTPTransport(), storage=self.cache_storage)
+
+            http_transport = httpx.HTTPTransport()
+            cache_transport = hishel.CacheTransport(transport=http_transport, storage=self.cache_storage)
             cache_controller = hishel.Controller(cacheable_methods=["GET", "POST"])
+
+            # Have to manually build the proxy mounts as httpx will not auto-discover
+            # proxies if we provide our own HTTPTransport to the Client constructor
+            proxy_mounts = self._build_caching_proxy_mounts()
             self.http_client = hishel.CacheClient(
-                controller=cache_controller, transport=cache_transport, storage=self.cache_storage
+                controller=cache_controller, transport=cache_transport, storage=self.cache_storage, mounts=proxy_mounts
             )
             self.http_client_setup = True
+
+    def _build_caching_proxy_mounts(self) -> PROXY_MOUNT:
+        """
+        Builds the proxy mounts for case where we have a CacheTransport.
+        Autodiscovery of proxies only works when don't provide a transport
+        to the client so this method acts as a replacement for that
+        """
+        proxy_map = httpx._utils.get_environment_proxies()
+        proxy_mounts: PROXY_MOUNT = {}
+        for key, proxy in proxy_map.items():
+            proxy_transport = None
+            if proxy is not None:
+                proxy_transport = httpx.HTTPTransport(
+                    verify=True,
+                    cert=None,
+                    trust_env=True,
+                    http1=True,
+                    http2=False,
+                    limits=httpx._config.DEFAULT_LIMITS,
+                    proxy=proxy,
+                )
+            proxy_mounts[key] = proxy_transport
+        proxy_mounts = dict(sorted(proxy_mounts.items()))
+        return proxy_mounts
 
     def __del__(self):
         """

--- a/biothings_client/utils/_external.py
+++ b/biothings_client/utils/_external.py
@@ -1,0 +1,36 @@
+"""
+Any functions we provide as auxillary or helper
+functions for the client are stored here and exposed in the
+__init__ for usage by the users
+
+We likely don't use these throughout the biothings.api core
+code, but the users might so we want to maintain that here while
+also indicating the purposes of the collection of functions in the
+module
+"""
+
+from typing import Any, Union
+
+
+def alwayslist(value: Any) -> Union[list, tuple]:
+    """
+    Simple transformation function that ensures the output is an iterable.
+
+    Control Flow:
+    If the input value is a {list, tuple}, we no-opt and return the value unchanged
+    Otherwise, we wrap the value in a list and then return that list
+
+    Example:
+
+    >>> x = 'abc'
+    >>> for xx in alwayslist(x):
+    ...     print xx
+    >>> x = ['abc', 'def']
+    >>> for xx in alwayslist(x):
+    ...     print xx
+
+    """
+    if isinstance(value, (list, tuple)):
+        return value
+    else:
+        return [value]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,8 @@
 Fixtures for the biothings_client testing
 """
 
+import os
+
 import pytest
 
 from biothings_client import get_client, get_async_client
@@ -111,3 +113,12 @@ def async_geneset_client() -> AsyncMyGenesetInfo:
     client = "geneset"
     geneset_client = get_async_client(client)
     return geneset_client
+
+
+@pytest.fixture(scope="function")
+def mock_client_proxy_configuration() -> None:
+    os.environ["HTTP_PROXY"] = "http://fakehttpproxyhost:6374"
+    os.environ["HTTPS_PROXY"] = "http://fakehttpsproxyhost:6375"
+    yield
+    os.environ.pop("HTTP_PROXY", None)
+    os.environ.pop("HTTPS_PROXY", None)

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -4,6 +4,7 @@ Test suite for the async client
 
 from typing import List
 
+import httpx
 import pytest
 
 import biothings_client
@@ -82,3 +83,35 @@ async def test_url_protocol(client_name: str):
     # Transform back to HTTPS
     client_instance.use_https()
     client_instance.url.startswith(https_protocol)
+
+
+@pytest.mark.asyncio
+async def test_async_client_proxy_discovery(mock_client_proxy_configuration):
+    """
+    Tests for verifying that we properly auto-discover the
+    proxy configuration from the environment using the built-in
+    methods provided by HTTPX
+
+    Brought to light by user issues on VPN
+    https://github.com/biothings/mygene.py/issues/26#issuecomment-2588065562
+    """
+    client_name = "gene"
+    gene_client = biothings_client.get_async_client(client_name)
+    await gene_client._build_http_client()
+    for url_pattern, http_transport in gene_client.http_client._mounts.items():
+        assert isinstance(url_pattern, httpx._utils.URLPattern)
+        assert isinstance(http_transport, httpx.AsyncHTTPTransport)
+
+        if url_pattern.pattern == "https://":
+            proxy_url = http_transport._pool._proxy_url
+            assert proxy_url.scheme == b"http"
+            assert proxy_url.host == b"fakehttpsproxyhost"
+            assert proxy_url.port == 6375
+            assert proxy_url.target == b"/"
+
+        elif url_pattern.pattern == "http://":
+            proxy_url = http_transport._pool._proxy_url
+            assert proxy_url.scheme == b"http"
+            assert proxy_url.host == b"fakehttpproxyhost"
+            assert proxy_url.port == 6374
+            assert proxy_url.target == b"/"

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -137,7 +137,7 @@ async def test_async_cache_client_proxy_discovery(mock_client_proxy_configuratio
 
     for url_pattern, http_transport in gene_client.http_client._mounts.items():
         assert isinstance(url_pattern, httpx._utils.URLPattern)
-        assert isinstance(http_transport, httpx.HTTPTransport)
+        assert isinstance(http_transport, httpx.AsyncHTTPTransport)
 
         if url_pattern.pattern == "https://":
             proxy_url = http_transport._pool._proxy_url

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -118,6 +118,7 @@ async def test_async_client_proxy_discovery(mock_client_proxy_configuration):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(not biothings_client._CACHING, reason="caching libraries not installed")
 async def test_async_cache_client_proxy_discovery(mock_client_proxy_configuration):
     """
     Tests for verifying that we properly auto-discover the

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -115,3 +115,40 @@ async def test_async_client_proxy_discovery(mock_client_proxy_configuration):
             assert proxy_url.host == b"fakehttpproxyhost"
             assert proxy_url.port == 6374
             assert proxy_url.target == b"/"
+
+
+@pytest.mark.asyncio
+async def test_async_cache_client_proxy_discovery(mock_client_proxy_configuration):
+    """
+    Tests for verifying that we properly auto-discover the
+    proxy configuration from the environment using the built-in
+    methods provided by HTTPX
+
+    Brought to light by user issues on VPN
+    https://github.com/biothings/mygene.py/issues/26#issuecomment-2588065562
+    """
+    client_name = "gene"
+    gene_client = biothings_client.get_async_client(client_name)
+    await gene_client._build_cache_http_client()
+
+    http_mounts = gene_client.http_client._mounts
+    assert isinstance(http_mounts, dict)
+    assert len(http_mounts) == 2
+
+    for url_pattern, http_transport in gene_client.http_client._mounts.items():
+        assert isinstance(url_pattern, httpx._utils.URLPattern)
+        assert isinstance(http_transport, httpx.HTTPTransport)
+
+        if url_pattern.pattern == "https://":
+            proxy_url = http_transport._pool._proxy_url
+            assert proxy_url.scheme == b"http"
+            assert proxy_url.host == b"fakehttpsproxyhost"
+            assert proxy_url.port == 6375
+            assert proxy_url.target == b"/"
+
+        elif url_pattern.pattern == "http://":
+            proxy_url = http_transport._pool._proxy_url
+            assert proxy_url.scheme == b"http"
+            assert proxy_url.host == b"fakehttpproxyhost"
+            assert proxy_url.port == 6374
+            assert proxy_url.target == b"/"

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -4,6 +4,7 @@ Test suite for the sync client
 
 from typing import List
 
+import httpx
 import pytest
 
 import biothings_client
@@ -79,3 +80,34 @@ def test_url_protocol(client_name: str):
     # Transform back to HTTPS
     client_instance.use_https()
     client_instance.url.startswith(https_protocol)
+
+
+def test_client_proxy_discovery(mock_client_proxy_configuration):
+    """
+    Tests for verifying that we properly auto-discover the
+    proxy configuration from the environment using the built-in
+    methods provided by HTTPX
+
+    Brought to light by user issues on VPN
+    https://github.com/biothings/mygene.py/issues/26#issuecomment-2588065562
+    """
+    client_name = "gene"
+    gene_client = biothings_client.get_client(client_name)
+    gene_client._build_http_client()
+    for url_pattern, http_transport in gene_client.http_client._mounts.items():
+        assert isinstance(url_pattern, httpx._utils.URLPattern)
+        assert isinstance(http_transport, httpx.HTTPTransport)
+
+        if url_pattern.pattern == "https://":
+            proxy_url = http_transport._pool._proxy_url
+            assert proxy_url.scheme == b"http"
+            assert proxy_url.host == b"fakehttpsproxyhost"
+            assert proxy_url.port == 6375
+            assert proxy_url.target == b"/"
+
+        elif url_pattern.pattern == "http://":
+            proxy_url = http_transport._pool._proxy_url
+            assert proxy_url.scheme == b"http"
+            assert proxy_url.host == b"fakehttpproxyhost"
+            assert proxy_url.port == 6374
+            assert proxy_url.target == b"/"

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -118,6 +118,7 @@ def test_client_proxy_discovery(mock_client_proxy_configuration):
             assert proxy_url.target == b"/"
 
 
+@pytest.mark.skipif(not biothings_client._CACHING, reason="caching libraries not installed")
 def test_cache_client_proxy_discovery(mock_client_proxy_configuration):
     """
     Tests for verifying that we properly auto-discover the


### PR DESCRIPTION
Corrections:

1. Adds an `external` utility module for denoting any functions we wish to expose to the end-users in one place so we can track potential auxiliary functions all in one location. Re-adds the `alwayslist` function as well
2. Adds attempted support for auto-discovery of any network proxies used. For the non-cache client this was trivial. Due to the `httpx.Client` design it appears that when you pass an `HTTPTransport` to the client constructor, it will not attempt to auto-discover any proxy settings from the environment. This is the preferred route for our library however, so for the non-caching case we simply remove the `HTTPTransport` from the constructor as isn't required. For the caching case we must supply an `HTTPTransport` for the `hishel` library to properly enable caching. So I added a stubbed out private method that mimics what `httpx` was doing under the hood to build the proxy mounts and pass those into the `CacheClient` constructor. Additionally added tests to verify that those proxies get passed along which they appear to be doing properly at the moment. This was highlighted in this [issue](https://github.com/biothings/mygene.py/issues/26). Thanks @mccauleyp for the detailed debugging in that issue highlighting the problems they were experiencing